### PR TITLE
modules/scrutiny: make firewall port configurable

### DIFF
--- a/modules/nixos/scrutiny.nix
+++ b/modules/nixos/scrutiny.nix
@@ -101,7 +101,7 @@ in
     };
 
     networking.firewall = lib.mkIf cfg.openFirewall {
-      allowedTCPPorts = [ 8080 ];
+      allowedTCPPorts = [ cfg.port ];
     };
 
     services.smartd = {


### PR DESCRIPTION
Saw your [cool article](https://jnsgr.uk/2024/02/packaging-scrutiny-for-nixos/#try-it) on Scrutiny. Went to try it out and figured I'd push up a patch I made.

If the user sets a new value for `cfg.port` and sets `cfg.openFirewall = true`, IMO, it should be reflected in the port that is opened.